### PR TITLE
Add API base, docker containerization

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+    api:
+        image: node:19
+        user: node
+        working_dir: /home/node/app
+        volumes:
+            - ./:/home/node/app
+        depends_on:
+            - redis
+        ports:
+            - "3003:3000"
+        command: yarn start
+
+    redis:
+        image: redis:latest
+        restart: unless-stopped
+
+networks:
+    default:
+        name: 472-project

--- a/package.json
+++ b/package.json
@@ -12,11 +12,13 @@
     "build:ci": "tsc --noEmit",
     "clean": "rimraf ./dist",
     "lint": "eslint . --ext .ts",
-    "postinstall": "is-ci || husky install"
+    "postinstall": "is-ci || husky install",
+    "start": "yarn build && node dist"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.1.2",
     "@commitlint/config-conventional": "^17.1.0",
+    "@types/express": "^4.17.17",
     "@typescript-eslint/eslint-plugin": "^5.40.1",
     "@typescript-eslint/parser": "^5.40.1",
     "eslint": "^8.25.0",
@@ -24,5 +26,8 @@
     "is-ci": "^3.0.1",
     "rimraf": "^4.1.1",
     "typescript": "^4.8.4"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+
+const app = express();
+
+app.get('/check', async (_, res) => {
+    res.sendStatus(200);
+});
+
+app.listen(3000, () => console.log('Server started'));


### PR DESCRIPTION
This PR sets up docker containerization using the node:19 and redis:latest docker images. This PR also sets up a base API project to be further expanded.

Closes #2 

## New endpoint: check

The `/check` endpoint may be used in order to check whether the API server is running properly. Returns 200 on success.