### PR TITLE
Fix CI tasks

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,11 +7,10 @@ jobs:
     - name: Chekout Repository
       uses: actions/checkout@v3
 
-    - name: Install Node.JS v16
+    - name: Install Node.JS v19
       uses: actions/setup-node@v3
       with:
-        node-version: 16
-        cache: 'yarn'
+        node-version: 19
 
     - run: yarn install --frozen-lockfile
 


### PR DESCRIPTION
This PR changes the version of node in PR runs to 19. This PR also fixes an issue where the PR CI task would always fail due to improper yarn cache setup.