### PR TITLE
Add `/categories` endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ lib-cov
 *.gz
 *.swp
 
+# redis
+*.aof
+*.rdb
+
 pids
 logs
 results

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     redis:
         image: redis:latest
         restart: unless-stopped
+        expose:
+            - "6379"
 
 networks:
     default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
         restart: unless-stopped
         expose:
             - "6379"
+        volumes:
+            - ./data:/data
 
 networks:
     default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
             - redis
         ports:
             - "3003:3000"
-        command: yarn start
+        command: yarn start:nobuild
 
     redis:
         image: redis:latest

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "redis": "^4.6.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "clean": "rimraf ./dist",
     "lint": "eslint . --ext .ts",
     "postinstall": "is-ci || husky install",
-    "start": "yarn build && node dist"
+    "start": "yarn build && node dist",
+    "start:nobuild": "node dist"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.1.2",

--- a/src/db.ts
+++ b/src/db.ts
@@ -71,3 +71,14 @@ export async function fetchCategoryTypes(): Promise<SiteCategory[]> {
             return { id: obj.score, name: obj.value };
         });
 }
+
+/**
+ * Returns whether a given authorization header value is a valid admin key or not.
+ * @param authorization The authorization header value.
+ * @returns Whether the given header value is a valid admin key.
+ */
+export async function checkAdminAuth(authorization?: string) {
+    if (!authorization) return false;
+
+    return await redis.sIsMember('admin_keys', authorization);
+}

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,6 +1,25 @@
 import { createClient } from 'redis';
 
+type SiteCategory = {
+    id: number,
+    name: string
+}
+
 // define and connect redis client
-const redis = createClient();
+const redis = createClient({
+    url: 'redis://redis:6379'
+});
 redis.on('error', err => console.error('Encountered a redis client error:', err));
-await redis.connect();
+redis.connect();
+
+/**
+ * Returns all of the valid category types.
+ *
+ * This operation runs in O(log(N)+M) time complexity.
+ */
+export async function fetchCategoryTypes(): Promise<SiteCategory[]> {
+    return (await redis.zRangeWithScores('categories', 0, -1))
+        .map(obj => {
+            return { id: obj.score, name: obj.value };
+        });
+}

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,6 @@
+import { createClient } from 'redis';
+
+// define and connect redis client
+const redis = createClient();
+redis.on('error', err => console.error('Encountered a redis client error:', err));
+await redis.connect();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { addCategoryType, fetchCategoryTypes } from './db';
+import { addCategoryType, checkAdminAuth, fetchCategoryTypes } from './db';
 
 const app = express().use(express.json());
 
@@ -12,8 +12,12 @@ app.route('/categories')
         const body = await fetchCategoryTypes();
         await res.status(200).json(body);
     })
-    // TODO: Require admin auth
     .post(async (req, res) => {
+        const is_admin = await checkAdminAuth(req.headers.authorization);
+        if (!is_admin) {
+            return await res.sendStatus(401);
+        }
+
         const add_results = await addCategoryType(req.body.name);
         const res_body = { id: add_results.id, name: req.body.name };
         if (!add_results.is_new) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import { fetchCategoryTypes } from './db';
 
 const app = express();
 
@@ -8,7 +9,8 @@ app.get('/check', async (_, res) => {
 
 app.route('/categories')
     .get(async (_, res) => {
-        const body = await 
+        const body = await fetchCategoryTypes();
+        await res.status(200).json(body);
     });
 
 app.listen(3000, () => console.log('Server started'));

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import express from 'express';
-import { fetchCategoryTypes } from './db';
+import { addCategoryType, fetchCategoryTypes } from './db';
 
-const app = express();
+const app = express().use(express.json());
 
 app.get('/check', async (_, res) => {
     res.sendStatus(200);
@@ -11,6 +11,16 @@ app.route('/categories')
     .get(async (_, res) => {
         const body = await fetchCategoryTypes();
         await res.status(200).json(body);
+    })
+    // TODO: Require admin auth
+    .post(async (req, res) => {
+        const add_results = await addCategoryType(req.body.name);
+        const res_body = { id: add_results.id, name: req.body.name };
+        if (!add_results.is_new) {
+            return await res.status(409).json(res_body);
+        }
+
+        await res.status(200).json(res_body);
     });
 
 app.listen(3000, () => console.log('Server started'));

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,9 @@ app.get('/check', async (_, res) => {
     res.sendStatus(200);
 });
 
+app.route('/categories')
+    .get(async (_, res) => {
+        const body = await 
+    });
+
 app.listen(3000, () => console.log('Server started'));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,10 @@
 {
     "compilerOptions": {
-      "target": "es2016",
-      "module": "commonjs",
+      "target": "es2017",
+      "module": "esnext",
       "declaration": true,
       "outDir": "./dist",
+      "moduleResolution": "node",
       "esModuleInterop": true,
       "forceConsistentCasingInFileNames": true,
       "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
       "target": "es2017",
-      "module": "esnext",
+      "module": "commonjs",
       "declaration": true,
       "outDir": "./dist",
       "moduleResolution": "node",


### PR DESCRIPTION
This PR adds support for the `/categories` endpoint.

## GET `/categories`

Returns a list of valid site category id's and their associated names

## POST `/categories`

Adds a new site category type. Returns a 200 and the category data on success. Returns a 409 and the category data if a category already exists with the given name.